### PR TITLE
Use 'not' for handling empty messages

### DIFF
--- a/iron_celery/iron_mq_transport.py
+++ b/iron_celery/iron_mq_transport.py
@@ -38,8 +38,13 @@ class IronMQChannel(BaseChannel):
     def _get(self, queue):
         messages = self.client.getMessage(queue)
 
-        if len(messages["messages"]) == 0:
+        # 'not' not only handles empty lists but anything
+        # valued as None
+        if not messages["messages"]:
             raise Empty()
+
+        #if len(messages["messages"]) == 0:
+        #    raise Empty()
 
         message = messages["messages"][0]
         parsed_message = loads(message['body'])


### PR DESCRIPTION
We've been getting this type of error in the past few days:

File "build/bdist.linux-x86_64/egg/iron_celery/iron_mq_transport.py", line 41, in _get
    if len(messages["messages"]) == 0:
TypeError: object of type 'NoneType' has no len()

This pull request fixes it.
