### PR TITLE
Fixed bug in IronCacheBackend that could cause crashing of celery worker...

### DIFF
--- a/iron_celery/iron_cache_backend.py
+++ b/iron_celery/iron_cache_backend.py
@@ -12,7 +12,8 @@ class IronCacheBackend(KeyValueStoreBackend):
     def __init__(self, url = None, *args, **kwargs):
         super(IronCacheBackend, self).__init__(*args, **kwargs)
 
-        _, self._host, _, self._project_id, self._token, self._ncache, _ = _parse_url(url)
+        if url:
+            _, self._host, _, self._project_id, self._token, self._ncache, _ = _parse_url(url)
 
         if self._ncache == None:
             self._ncache = "Celery" 


### PR DESCRIPTION
When celery pickles/unpickles the results backend the url can sometimes be None which resulted in a crash even though the pickling would restore all of the appropriate variables.

This change simple skips over parsing the url where a crash was occurring if the url passed in was None. This theoretically could be dangerous as you could have a corrupt backend but many of celery's built in backends use this same method.
