### PR TITLE
Iron celery v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: We recommend using [virtualenv](http://www.virtualenv.org/) to avoid any d
 
 For IronMQ support, you'll need the [iron_celery](http://github.com/iron-io/iron_celery) library:
 
-    $ pip install iron_celery
+    $ pip install iron-celery-v3
 
 As well as an Iron.io account. Sign up for free at [Iron.io](http://www.iron.io/celery).
 
@@ -28,11 +28,11 @@ First, you'll need to import the iron_celery library right after you import Cele
 
 To use IronMQ, the broker URL should be in this format:
 
-    BROKER_URL = 'ironmq://ABCDEFGHIJKLMNOPQRST:ZYXK7NiynGlTogH8Nj+P9nlE73sq3@?connect_timeout=20'
+    BROKER_URL = 'ironmq://ABCDEFGHIJKLMNOPQRST:ZYXK7NiynGlTogH8Nj+P9nlE73sq3@some_v3_host?connect_timeout=20'
 
 where the URL format is:
 
-    ironmq://project_id:token@connect_timeout
+    ironmq://project_id:token@host?connect_timeout
 
 The project_id and token are for your Iron.io account, you can find these in the [Iron.io HUD](http://hud.iron.io).
 You must *remember to include the "@" at the end*.

--- a/iron_celery/iron_mq_transport.py
+++ b/iron_celery/iron_mq_transport.py
@@ -14,7 +14,7 @@ class IronMQChannel(BaseChannel):
         if self._client is None:
             conninfo = self.connection.client
             hostname = conninfo.hostname
-            self._client = IronMQ(project_id = conninfo.userid, token = conninfo.password, host = None if hostname == "localhost" else hostname, api_version=3)
+            self._client = IronMQ(project_id = conninfo.userid, token = conninfo.password, host = None if hostname == "localhost" else hostname)
 
         return self._client
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from distutils.core import setup
 
 setup(
-    name = "iron_celery",
+    name = "iron-celery-v3",
     packages = ["iron_celery"],
-    install_requires = ["iron_mq", "iron_cache", "celery"],
+    install_requires = ["iron-mq-v3", "iron_cache", "celery"],
     version = "0.4.1",
     description = "IronMQ transport and IronCache backend for Celery",
     author = "Iron.io",
     author_email = "info@iron.io",
-    url = "https://github.com/iron-io/iron_celery"
+    url = "https://github.com/iron-io/iron_celery/tree/v3"
 )


### PR DESCRIPTION
- Corrected README file
- change name of installation with pip: pip install iron-celery-v3
