### PR TITLE
Add Python 3 compatability

### DIFF
--- a/iron_celery/iron_mq_transport.py
+++ b/iron_celery/iron_mq_transport.py
@@ -3,7 +3,10 @@ from iron_mq import IronMQ
 from kombu.transport.virtual import Channel as BaseChannel
 from kombu.transport.virtual import Transport as BaseTransport
 from anyjson import loads, dumps
-from Queue import Empty
+try:
+    from queue import Empty
+except ImportError:  # Python 2 compatibility
+    from Queue import Empty
 from kombu.transport.virtual import scheduling
 from kombu.utils.encoding import bytes_to_str
 


### PR DESCRIPTION
In Python 3 the `Queue` module became the `queue` module, so we should try importing from that first.

'iron-mq' is not yet Python 3 compatible, but [there is a pull request to fix that](https://github.com/iron-io/iron_mq_python/pull/20) as well.
